### PR TITLE
Remove FLASK_DEBUG=true

### DIFF
--- a/root/etc/services.d/flask/run
+++ b/root/etc/services.d/flask/run
@@ -1,6 +1,5 @@
 #!/usr/bin/with-contenv sh
 
-export FLASK_DEBUG=1
 export FLASK_APP=app.py
 export FLASK_APP=/app/app.py
 exec flask run --host=0.0.0.0 --port=80


### PR DESCRIPTION
When a Flask application is running in debug mode, it'll e.g. show stacktraces and other sensitive information. This is usually probably a bad idea for challenges, as it might make exploiting easier than intended. It's also not possible to override this in the .env file.